### PR TITLE
Fixed some issues regarding pointers on Android and Web

### DIFF
--- a/packages/three_js_core/lib/others/peripherals.dart
+++ b/packages/three_js_core/lib/others/peripherals.dart
@@ -134,11 +134,11 @@ class PeripheralsState extends State<Peripherals> {
         },
         child: Listener(
           onPointerPanZoomStart: panGestureRecognizer.addPointerPanZoom,
-          // onPointerSignal: (event) {
-          //   if (event is PointerScrollEvent) {
-          //     _onPointerEvent(context, PeripheralType.wheel, event);
-          //   }
-          // },
+          onPointerSignal: (event) {
+            if (event is PointerScrollEvent) {
+              _onPointerEvent(context, PeripheralType.wheel, event);
+            }
+          },
           onPointerDown: (PointerDownEvent event) {
             _pointers++;
             _onPointerEvent(context, PeripheralType.pointerdown, event);

--- a/packages/three_js_core/lib/others/peripherals.dart
+++ b/packages/three_js_core/lib/others/peripherals.dart
@@ -56,6 +56,7 @@ class PeripheralsState extends State<Peripherals> {
   late final PanGestureRecognizer panGestureRecognizer;
 
   double _prevScale = 0;
+  int _pointers = 0;
 
   @override
   void initState() {
@@ -139,6 +140,7 @@ class PeripheralsState extends State<Peripherals> {
           //   }
           // },
           onPointerDown: (PointerDownEvent event) {
+            _pointers++;
             _onPointerEvent(context, PeripheralType.pointerdown, event);
             FocusScope.of(context).requestFocus(focusNode);
           },
@@ -146,7 +148,12 @@ class PeripheralsState extends State<Peripherals> {
             _onPointerEvent(context, PeripheralType.pointermove, event);
           },
           onPointerUp: (PointerUpEvent event) {
+            _pointers--;
             _onPointerEvent(context, PeripheralType.pointerup, event);
+          },
+          onPointerCancel: (PointerCancelEvent event) {
+            _pointers--;
+            _onPointerEvent(context, PeripheralType.pointercancel, event);
           },
           onPointerHover: (PointerHoverEvent event){
             _onPointerEvent(context, PeripheralType.pointerHover , event);
@@ -166,15 +173,15 @@ class PeripheralsState extends State<Peripherals> {
   }
 
   void _onScaleEvent(BuildContext context, PeripheralType type, event) {
-    final wpe = WebPointerEvent.fromScaleEvent(context, event);
+    final wpe = WebPointerEvent.fromScaleEvent(context, event, _pointers);
     _emit(type, wpe);
   }
   void _onDragEvent(BuildContext context, PeripheralType type, event) {
-    final wpe = WebPointerEvent.fromDragEvent(context, event);
+    final wpe = WebPointerEvent.fromDragEvent(context, event, _pointers);
     _emit(type, wpe);
   }
   void _onPointerEvent(BuildContext context, PeripheralType type, PointerEvent event) {
-    final wpe = WebPointerEvent.fromPointerEvent(context, event);
+    final wpe = WebPointerEvent.fromPointerEvent(context, event, _pointers);
     _emit(type, wpe);
   }
 
@@ -252,12 +259,13 @@ class WebPointerEvent {
     }
   }
 
-  static WebPointerEvent convertPointerEvent(BuildContext context, PointerEvent event) {
+  static WebPointerEvent convertPointerEvent(BuildContext context, PointerEvent event, int pointerCount) {
     final wpe = WebPointerEvent();
 
     wpe.pointerId = event.pointer;
     wpe.pointerType = getPointerType(event);
     wpe.button = getButton(event);
+    wpe.pointerCount = pointerCount;
 
     RenderBox getBox = context.findRenderObject() as RenderBox;
     final local = getBox.globalToLocal(event.position);
@@ -296,12 +304,13 @@ class WebPointerEvent {
     return wpe;
   }
 
-  static WebPointerEvent convertDragEvent(BuildContext context, event) {
+  static WebPointerEvent convertDragEvent(BuildContext context, event, int pointerCount) {
     final wpe = WebPointerEvent();
 
     wpe.pointerId = 512;
     wpe.pointerType = 'touch_pad';
     wpe.button = 0;
+    wpe.pointerCount = pointerCount;
 
     RenderBox getBox = context.findRenderObject() as RenderBox;
     final local = getBox.globalToLocal(event.globalPosition);
@@ -333,12 +342,13 @@ class WebPointerEvent {
 
     return wpe;
   }
-  static WebPointerEvent convertScaleEvent(BuildContext context, event) {
+  static WebPointerEvent convertScaleEvent(BuildContext context, event, int pointerCount) {
     final wpe = WebPointerEvent();
 
     wpe.pointerId = 522;
     wpe.pointerType = 'mouse';
     wpe.button = 4;
+    wpe.pointerCount = pointerCount;
 
     wpe.clientX = event['scale'];
     wpe.clientY = event['scale'];
@@ -369,14 +379,14 @@ class WebPointerEvent {
     return wpe;
   }
 
-  factory WebPointerEvent.fromPointerEvent(BuildContext context, PointerEvent event) {
-    return convertPointerEvent(context, event);
+  factory WebPointerEvent.fromPointerEvent(BuildContext context, PointerEvent event, int pointerCount) {
+    return convertPointerEvent(context, event, pointerCount);
   }
-  factory WebPointerEvent.fromDragEvent(BuildContext context, event) {
-    return convertDragEvent(context, event);
+  factory WebPointerEvent.fromDragEvent(BuildContext context, event, int pointerCount) {
+    return convertDragEvent(context, event, pointerCount);
   }
-  factory WebPointerEvent.fromScaleEvent(BuildContext context, event) {
-    return convertScaleEvent(context, event);
+  factory WebPointerEvent.fromScaleEvent(BuildContext context, event, int pointerCount) {
+    return convertScaleEvent(context, event, pointerCount);
   }
   @override
   String toString() {


### PR DESCRIPTION
- Fixed an issue on Android, where activating the navigate back animation and cancelling it would not remove the previous pointer due to missing onPointerCancel callback
- Added pointers count to the click, drag and scale events to be able to better integrate custom actions to these gestures (such as using the pointer move event to only rotate a model in the scene and not the entire scene)
- Uncommented the code that prevents the scroll wheel from zooming in and out using OrbitControls on the Web.