### PR TITLE
Fix for issue 68

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -43,3 +43,7 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# FVM Version Cache
+*.fvmrc
+.fvm/

--- a/packages/three_js_core/lib/others/peripherals.dart
+++ b/packages/three_js_core/lib/others/peripherals.dart
@@ -197,6 +197,7 @@ class PeripheralsState extends State<Peripherals> {
 }
 
 class WebPointerEvent {
+  int pointerCount = 0;
   late int pointerId;
   late int button;
   String pointerType = 'touch';

--- a/packages/three_js_core/lib/others/three_viewer.dart
+++ b/packages/three_js_core/lib/others/three_viewer.dart
@@ -163,7 +163,7 @@ class ThreeJS {
    initPlatformState();
   }
   
-  void animate(Duration duration) {
+  Future<void> animate(Duration duration) async {
     if (!mounted || disposed || updating) {
       return;
     }
@@ -171,7 +171,7 @@ class ThreeJS {
     double dt = clock.getDelta();
     
     if(settings.animate){
-      render(dt);
+      await render(dt);
       if(!pause){
         for(int i = 0; i < events.length;i++){
           events[i].call(dt);


### PR DESCRIPTION
Fix for issue 68 "Crash on Windows while moving window with ThreeJs.build() widget visible". It seems the only change needed was to change line 174 of packages/three_js_core/lib/others/three_viewer.dart to 'await render(dt);'. It was not awaited.