### PR TITLE
protect windowResize from disposed tree

### DIFF
--- a/packages/three_js_core/lib/others/three_viewer.dart
+++ b/packages/three_js_core/lib/others/three_viewer.dart
@@ -258,10 +258,11 @@ class ThreeJS with WidgetsBindingObserver{
   }
   
   Future<void> onWindowResize(BuildContext context) async{
+    if (disposed) return;
     double dt = clock.getDelta();
-    final mqd = MediaQuery.of(context);
+    final mqd = MediaQuery.maybeOf(context);
+    if (mqd == null) return;
     if(_size == null && screenSize != mqd.size && texture != null){
-      print('SIZES: ${mqd.size}, ${screenSize}');
       screenSize = mqd.size;
       width = screenSize!.width;
       height = screenSize!.height;


### PR DESCRIPTION
This snippet change prevents from null errors when onResize occurs in a disposed or unavailable widget tree, could also be related to using overlays and other means of developing the UI.