### PR TITLE
Allow a ThreeJS object to be reused for the lifetime of the app.

### DIFF
--- a/packages/three_js_advanced_loaders/lib/gltf/gltf_parser.dart
+++ b/packages/three_js_advanced_loaders/lib/gltf/gltf_parser.dart
@@ -892,8 +892,8 @@ class GLTFParser {
 
       if (materialDef["normalTexture"]["scale"] != null) {
         materialParams["normalScale"] = Vector2(
-            materialDef["normalTexture"]['scale'],
-            materialDef["normalTexture"]['scale']);
+            materialDef["normalTexture"]["scale"],
+            materialDef["normalTexture"]["scale"]);
       }
     }
 

--- a/packages/three_js_core/lib/others/three_viewer.dart
+++ b/packages/three_js_core/lib/others/three_viewer.dart
@@ -90,7 +90,7 @@ class ThreeJS with WidgetsBindingObserver{
   bool visible = true;
 
   FlutterAngleTexture? texture;
-  late final RenderingContext gl;
+  RenderingContext? gl;
 
   core.WebGLRenderTarget? renderTarget;
   core.WebGLRenderer? renderer;
@@ -301,7 +301,9 @@ class ThreeJS with WidgetsBindingObserver{
   }
 
   Future<void> initScene() async{
-    initRenderer();
+    if (renderer == null) {
+      initRenderer();
+    }
     await setup?.call();
     mounted = true;
     ticker = Ticker(animate);
@@ -327,7 +329,9 @@ class ThreeJS with WidgetsBindingObserver{
     }
 
     console.info(texture?.toMap());
-    gl = texture!.getContext();
+    if (gl == null) {
+      gl = texture!.getContext();
+    }
     await initScene();
   }
 

--- a/packages/three_js_core/lib/renderers/web_gl_renderer.dart
+++ b/packages/three_js_core/lib/renderers/web_gl_renderer.dart
@@ -21,8 +21,8 @@ class WebGLRenderer {
   bool reverseDepthBuffer = false;
 
   bool renderBackground = false;
-  late WebGLRenderList? currentRenderList;
-  late WebGLRenderState? currentRenderState;
+  WebGLRenderList? currentRenderList;
+  WebGLRenderState? currentRenderState;
 
   // render() can be called from within a callback triggered by another render.
 

--- a/packages/three_js_core_loaders/lib/ImageLoader/image_loader_web.dart
+++ b/packages/three_js_core_loaders/lib/ImageLoader/image_loader_web.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 //import 'dart:ui' as ui;
 import 'package:web/web.dart' as html;
 import 'dart:convert';
+import 'dart:ui' as ui;
 import 'package:three_js_core/three_js_core.dart';
 
 import '../utils/blob.dart';
@@ -120,11 +121,11 @@ Future<html.HTMLImageElement> createImageElementFromBytes(Uint8List bytes, [Stri
   // Create an ImageElement and set its source to the data URL
   html.HTMLImageElement imageElement = html.HTMLImageElement();
   imageElement.src = dataUrl;
-  //int start = DateTime.now().millisecondsSinceEpoch;
-  //print(DateTime.now());
-  List? dimensions = _getJpegDimensions(bytes);//await _getDimensions(bytes);//
-  //print(DateTime.now().millisecondsSinceEpoch-start);
-  //imageElement = setDimensions(imageElement, dimensions);
+  // int start = DateTime.now().millisecondsSinceEpoch;
+  // print(start);
+  List? dimensions = await _getDimensions(bytes);
+  // print(DateTime.now().millisecondsSinceEpoch-start);
+  // imageElement = setDimensions(imageElement, dimensions);
   if (dimensions != null) {
     console.verbose("extracted dimension width ${dimensions[0]} and height ${dimensions[1]}");
     imageElement.width = dimensions[0];
@@ -152,8 +153,8 @@ Future<ImageElement?> processImage(Uint8List? bytes, String? url, bool flipY) as
         url: url,
         data: imageElement,
         width: imageElement.width,
-        height: imageElement.height
-      )
+        height: imageElement.height,
+      ),
     );
   }
   else{

--- a/packages/three_js_core_loaders/lib/ImageLoader/image_loader_web.dart
+++ b/packages/three_js_core_loaders/lib/ImageLoader/image_loader_web.dart
@@ -67,15 +67,15 @@ html.HTMLImageElement setDimensions(html.HTMLImageElement imageElement, String? 
   return imageElement;
 }
 
-// Future<List>? _getDimensions(Uint8List bytes) async{
-//   final codec = await ui.instantiateImageCodec(bytes);
-//   final frameInfo = await codec.getNextFrame();
-//   final width = frameInfo.image.width;
-//   final height = frameInfo.image.height;
-//   frameInfo.image.dispose();
+Future<List>? _getDimensions(Uint8List bytes) async{
+  final codec = await ui.instantiateImageCodec(bytes);
+  final frameInfo = await codec.getNextFrame();
+  final width = frameInfo.image.width;
+  final height = frameInfo.image.height;
+  frameInfo.image.dispose();
 
-//   return [width, height];
-// }
+  return [width, height];
+}
 
 List? _getJpegDimensions(Uint8List bytes) {
   // Verify the JPEG header (SOI marker)


### PR DESCRIPTION
When running on web, creating a `ThreeJS` object also creates a new WebGL context instance and there's a hard limit of the number of WebGL contexts that can be created on web. The changes in this PR allow the web apps that depend on the `three_js` package to only create a `ThreeJS` object once and reuse it throughout the lifetime of the app.

The PR also changes the way image dimensions are retrieved. Previously only JPEG image were supported through the use of `_getJpegDimensions`. This is now replaced with `_getDimensions`, that allow any kind of image to be used.