### PR TITLE
Made _context nullable in three_viewer.dart, so that the ThreeJs object can be reused

### DIFF
--- a/packages/three_js_core/lib/others/three_viewer.dart
+++ b/packages/three_js_core/lib/others/three_viewer.dart
@@ -100,7 +100,7 @@ class ThreeJS with WidgetsBindingObserver{
 
   int renderNumber;
 
-  late final BuildContext _context;
+  BuildContext? _context;
   Timer? _debounceTimer;
 
   Widget? loadingWidget;
@@ -154,7 +154,9 @@ class ThreeJS with WidgetsBindingObserver{
     if (disposed) return;
     _debounceTimer?.cancel(); // Clear existing timer
     _debounceTimer = Timer(const Duration(milliseconds: 300), () { // Set a new timer
-      onWindowResize(_context);
+      if (_context != null && _context!.mounted) {
+        onWindowResize(_context!);
+      }
     });
   }
 


### PR DESCRIPTION
Made _context nullable in three_viewer.dart, so that the ThreeJs object can be reused on web to prevent crashes after creating multiple instances and the GPU does not deallocate them fast enough.
Furthermore, checking if the context is mounted is always a good thing to do in async operations.