### PR TITLE
Fix error infinite_grid_helper.dart on creation

### DIFF
--- a/packages/three_js_helpers/lib/infinite_grid_helper.dart
+++ b/packages/three_js_helpers/lib/infinite_grid_helper.dart
@@ -38,7 +38,7 @@ class InfiniteGridHelper extends Mesh {
     uniform float uDistance;
 
     void main() {
-        vec3 pos = position.$axes * uDistance;
+        vec3 pos = position.${axes.name} * uDistance;
         pos.$planeAxes += cameraPosition.$planeAxes;
         
         worldPosition = pos;


### PR DESCRIPTION
Hi. 
Small error fix  on InfiniteGridHelper creation :
```
vec3 pos = [position.RotationOrders.xyz](http://position.rotationorders.xyz/) * uDistance; pos.xy += cameraPosition.xy; worldPosition = pos; gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);

->  false ERROR: 0:91: 'RotationOrders' : illegal vector field selection ERROR: 0:91: 'xyz' : field selection requires structure, 
vector, or interface block on left hand side ERROR: 0:91: '=' : dimension mismatch ERROR: 0:91: '=' : cannot convert from 'highp float' to 'highp 3-component vector of float'
```
Have a nice day.