### PR TITLE
fix peripherals.dart: correct middle mouse button handling

### DIFF
--- a/packages/three_js_core/lib/others/peripherals.dart
+++ b/packages/three_js_core/lib/others/peripherals.dart
@@ -341,7 +341,7 @@ class WebPointerEvent {
       // Left button takes precedence over other
       if (leftButtonPressed) return 0;
       // 2nd priority is the right button
-      if (rightButtonPressed || middleButtonPressed) return 2;
+      if (rightButtonPressed) return 2;
       // Lastly the middle button
       if (middleButtonPressed) return 1;
 


### PR DESCRIPTION
Previously, the condition `if (rightButtonPressed || middleButtonPressed)` prevented the middle button from ever returning its intended value (1). Now right button returns 2, and middle button returns 1 as expected. Fixes #104