### PR TITLE
Fix line and linesegments clone method. Similar to #113

### DIFF
--- a/packages/three_js_core/lib/objects/group.dart
+++ b/packages/three_js_core/lib/objects/group.dart
@@ -30,4 +30,18 @@ class Group extends Object3D {
   Group.fromJson(Map<String, dynamic> json, Map<String, dynamic> rootJson):super.fromJson(json, rootJson) {
     type = 'Group';
   }
+
+  @override
+  Group clone ([bool? recursive = true]) {
+    return Group()..copy(this, recursive);
+  }
+
+  @override
+  Group copy(Object3D source, [bool? recursive]) {
+    super.copy(source, recursive);
+    if(source is Group) {
+      this.userData = Map<String, dynamic>.from(source.userData);
+    }
+    return this;
+  }
 }

--- a/packages/three_js_core/lib/objects/line.dart
+++ b/packages/three_js_core/lib/objects/line.dart
@@ -55,8 +55,8 @@ class Line extends Object3D {
   Line copy(Object3D source, [bool? recursive]) {
     super.copy(source);
 
-    material = source.material;
-    geometry = source.geometry;
+    material = source.material?.clone();
+    geometry = source.geometry?.clone();
 
     return this;
   }

--- a/packages/three_js_core/lib/objects/line_segments.dart
+++ b/packages/three_js_core/lib/objects/line_segments.dart
@@ -56,4 +56,9 @@ class LineSegments extends Line {
 
     return this;
   }
+
+  @override
+  LineSegments clone([bool? recursive = true]) {
+    return LineSegments(this.geometry)..copy(this, recursive);
+  }
 }


### PR DESCRIPTION
Hi. 

I`ve done small fixes for clone/copy methods (**Group**, **Line**, **LIneSegments**).
Now **Group** clone() return **Group** type instead of  **Object3D** and **LineSegments**  clone() return LineSegments instead of Line.

This fixes similar to issue #113.

Have a nice day.